### PR TITLE
add configs for stow

### DIFF
--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -1,0 +1,4 @@
+<!-- Git -->
+.git
+README.md
+screenshots

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ There is no installation script yet, but in the meantime you can clone the repo 
 
 ```
 git clone https://github.com/lvntcnylmz/dotfiles.git
-cp -r dotfiles/.config/* ~/.config
+stow .
 ```
 
 ### TODO
 
-- [ ] Add installation script
+- [x] Add installation script
 - [ ] Better documentation
 
 ## Screenshots


### PR DESCRIPTION
You can use Stow as an alternative to installation scripts.

Only need to clone your repository into your home directory. Inside your repository, run the command `stow .`, this will replicate the folder structure by creating symbolic links in the corresponding directories.
Any changes made through these links will also affect the original files, making it faster to sync updates to GitHub.
